### PR TITLE
临时修复水鱼查分器 Api 无法使用问题

### DIFF
--- a/app/src/main/java/com/paperpig/maimaidata/network/MaimaiDataClient.kt
+++ b/app/src/main/java/com/paperpig/maimaidata/network/MaimaiDataClient.kt
@@ -19,7 +19,7 @@ class MaimaiDataClient private constructor() {
             MaimaiDataClient()
         }
 
-        const val BASE_URL = "https://www.diving-fish.com"
+        const val BASE_URL = "http://43.154.149.78:8392"
         const val IMAGE_BASE_URL = "https://maimaidx.jp/maimai-mobile/img/Music/"
 
     }


### PR DESCRIPTION
截止自 2024.11.11 域名解析依旧失效，故使用 ip 形式