### PR TITLE
perf: 等级表左右箭头

### DIFF
--- a/app/src/main/java/com/paperpig/maimaidata/ui/checklist/LevelCheckActivity.kt
+++ b/app/src/main/java/com/paperpig/maimaidata/ui/checklist/LevelCheckActivity.kt
@@ -70,6 +70,16 @@ class LevelCheckActivity : AppCompatActivity() {
         binding.switchBtn.setOnClickListener {
             (binding.levelCheckRecycler.adapter as LevelCheckAdapter).updateDisplay()
         }
+
+        binding.btnLeft.setOnClickListener {
+            binding.levelSlider.value -= 1f
+            searchLevelString = levelArrays[binding.levelSlider.value.toInt()]
+        }
+
+        binding.btnRight.setOnClickListener {
+            binding.levelSlider.value += 1f
+            searchLevelString = levelArrays[binding.levelSlider.value.toInt()]
+        }
     }
 
     private fun refreshDataList() {

--- a/app/src/main/res/layout/activity_level_check.xml
+++ b/app/src/main/res/layout/activity_level_check.xml
@@ -17,13 +17,33 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:gravity="center"
+        android:orientation="horizontal"
+        android:padding="8dp">
+
+        <Button
+            android:id="@+id/btnLeft"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/left_arrow"
+            android:textColor="@color/black"
+            android:backgroundTint="@android:color/transparent"
+            android:textSize="18sp" />
 
         <TextView
             android:id="@+id/level_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="12dp"
+            android:layout_marginHorizontal="16dp"
+            android:textSize="18sp" />
+
+        <Button
+            android:id="@+id/btnRight"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/right_arrow"
+            android:textColor="@color/black"
+            android:backgroundTint="@android:color/transparent"
             android:textSize="18sp" />
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,5 +163,7 @@
     <string name="vpn_connected_status">connected</string>
     <string name="vpn_disconnected_status">disconnected</string>
     <string name="vpn_please_login">请先登录查分器账户</string>
+    <string name="left_arrow">◀</string>
+    <string name="right_arrow">▶</string>
 
 </resources>


### PR DESCRIPTION
原因：手机上左右一格太短了，如果我要从13拖到12+我需要先拖到更小的定数然后拖回来（），所以加了一个左右按钮